### PR TITLE
Item Points Fix

### DIFF
--- a/database/migrations/2020_10_31_022911_create_webcms_procedure.php
+++ b/database/migrations/2020_10_31_022911_create_webcms_procedure.php
@@ -95,9 +95,7 @@ BEGIN
                                            INNER JOIN [{$databaseShard}].[dbo]._Inventory IV ON IV.CharID = CH.CharID
                                            INNER JOIN [{$databaseShard}].[dbo]._Items IT ON IT.ID64 = IV.ItemID
                                            INNER JOIN [{$databaseShard}].[dbo]._RefObjCommon RO ON IT.RefItemID = RO.ID
-                                           LEFT JOIN [{$databaseShard}].[dbo]._BindingOptionWithItem BOPT
-                                                     ON BOPT.nItemDBID = IT.ID64
-                                  WHERE IV.slot < 13
+[]                                  WHERE IV.slot < 13
                                     AND IV.slot <> 8
                                     AND IV.slot <> 7
                                     AND IV.CharID = CH.CharID

--- a/database/migrations/2020_10_31_022911_create_webcms_procedure.php
+++ b/database/migrations/2020_10_31_022911_create_webcms_procedure.php
@@ -165,7 +165,7 @@ BEGIN
                                     @strDesc VARCHAR(512)
                                 IF (@jobString LIKE 'Trader' OR @jobString LIKE 'Robber' OR @jobString LIKE 'Hunter')
                                     BEGIN
-                                        -- If it's a Job Kill, then write character nicknames
+                                        -- If it's a Job Kill, then write character nicknames.
 
                                         SET @strDesc = '[' + @KillerNickName + '] has killed [' + @KilledNickName +
                                                        '] on [' + @jobDesc + '] at [' +

--- a/database/migrations/2020_10_31_022911_create_webcms_procedure.php
+++ b/database/migrations/2020_10_31_022911_create_webcms_procedure.php
@@ -95,7 +95,7 @@ BEGIN
                                            INNER JOIN [{$databaseShard}].[dbo]._Inventory IV ON IV.CharID = CH.CharID
                                            INNER JOIN [{$databaseShard}].[dbo]._Items IT ON IT.ID64 = IV.ItemID
                                            INNER JOIN [{$databaseShard}].[dbo]._RefObjCommon RO ON IT.RefItemID = RO.ID
-[]                                  WHERE IV.slot < 13
+                                    WHERE IV.slot < 13
                                     AND IV.slot <> 8
                                     AND IV.slot <> 7
                                     AND IV.CharID = CH.CharID


### PR DESCRIPTION
There was a small issue with the item points fetching, a character with a chest as example, takes its points once but if this chest has a socket, it takes its points twice, 2 sockets, 3 times and so on, removed the join of _BindingOptionWithItem.